### PR TITLE
Added support for overriding username and channel when using legacy slack webhook 

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -9,6 +9,8 @@ slack:
   ### slack url contain webhook url for your workspace.
   ### Example:
   ###   url: "https://hooks.slack.com/services/TOKEN"
+  ###   username: "Siera Kube Watch"                        [OPTIONAL]
+  ###   channel: "#siera"                                   [OPTIONAL]
   url: "https://hooks.slack.com/services/TOKEN"
 
 ### For more information, refer to https://core.telegram.org/bots/api

--- a/config/config.go
+++ b/config/config.go
@@ -13,8 +13,10 @@ type Config struct {
 	}
 
 	Slack struct {
-		Enabled bool   `yaml:"enabled"`
-		Url     string `yaml:"url"`
+		Enabled  bool   `yaml:"enabled"`
+		Url      string `yaml:"url"`
+		Username string `yaml:"username"`
+		Channel  string `yaml:"channel"`
 	}
 
 	Telegram struct {

--- a/model/slack.go
+++ b/model/slack.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type SlackModel struct {
+	Text     string `json:"text"`
+	Channel  string `json:"channel"`
+	Username string `json:"username"`
+}
+
+func (model *SlackModel) New(text string, channel string, username string) {
+	model.Text = text
+	model.Channel = channel
+	model.Username = username
+}
+
+func (model *SlackModel) Send(url string) (err error) {
+	buffer, err := json.Marshal(model)
+	fmt.Println(string(buffer))
+	if err != nil {
+		return
+	}
+
+	err = postRequest(buffer, url)
+	return
+}

--- a/model/slack.go
+++ b/model/slack.go
@@ -3,6 +3,8 @@ package model
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/warungpintar/siera-kube-watch/config"
 )
 
 type SlackModel struct {
@@ -11,10 +13,10 @@ type SlackModel struct {
 	Username string `json:"username"`
 }
 
-func (model *SlackModel) New(text string, channel string, username string) {
+func (model *SlackModel) New(text string) {
 	model.Text = text
-	model.Channel = channel
-	model.Username = username
+	model.Channel = config.GlobalConfig.Slack.Channel
+	model.Username = config.GlobalConfig.Slack.Username
 }
 
 func (model *SlackModel) Send(url string) (err error) {

--- a/util/notify.go
+++ b/util/notify.go
@@ -59,7 +59,7 @@ func postEvent(message string) {
 
 	if config.GlobalConfig.Slack.Enabled {
 		model := model.SlackModel{}
-		model.New(message, config.GlobalConfig.Slack.Channel, config.GlobalConfig.Slack.Username)
+		model.New(message)
 		err := model.Send(config.GlobalConfig.Slack.Url)
 		if err != nil {
 			log.Println(err)

--- a/util/notify.go
+++ b/util/notify.go
@@ -58,8 +58,8 @@ func postEvent(message string) {
 	}
 
 	if config.GlobalConfig.Slack.Enabled {
-		model := model.StdModel{}
-		model.New(message)
+		model := model.SlackModel{}
+		model.New(message, config.GlobalConfig.Slack.Channel, config.GlobalConfig.Slack.Username)
 		err := model.Send(config.GlobalConfig.Slack.Url)
 		if err != nil {
 			log.Println(err)


### PR DESCRIPTION
https://api.slack.com/legacy/custom-integrations/messaging/webhooks#legacy-customizations

Added support to send the username and channel as the request payload to override the default username/channel when using the legacy webhook.

For non-legacy webhook, the field will be ignored by the slack server.