### PR TITLE
added dead man switch functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ Supported webhooks:
 - workplace chat
 - webhook
 
+It also supports liveness check (dead man's switch) functionality for alerting on availability of alerting pipeline.
+```
+livenesscheck:
+  enabled: true
+  interval: "1m"
+```
+
 # Build and Run
 
 ## Install Dependencies

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,6 +3,11 @@ webhook:
   enabled: true
   url: "http://127.0.0.1/webhook"
 
+### Enable dead man's switch functionality, similar to https://docs.openshift.com/container-platform/3.11/install_config/prometheus_cluster_monitoring.html#dead-mans-switch_prometheus-cluster-monitoring
+livenesscheck:
+  enabled: true
+  interval: "2s"
+
 ### For more information, refer to https://api.slack.com/messaging/webhooks
 slack:
   enabled: true

--- a/config/config.go
+++ b/config/config.go
@@ -1,15 +1,21 @@
 package config
 
 import (
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"log"
+
+	"gopkg.in/yaml.v2"
 )
 
 type Config struct {
 	Webhook struct {
 		Enabled bool   `yaml:"enabled"`
 		Url     string `yaml:"url"`
+	}
+
+	Livenesscheck struct {
+		Enabled  bool   `yaml:"enabled"`
+		Interval string `yaml:"interval"`
 	}
 
 	Slack struct {

--- a/liveness-check/checker.go
+++ b/liveness-check/checker.go
@@ -1,0 +1,28 @@
+package liveness_check
+
+import (
+	"log"
+	"time"
+
+	"github.com/warungpintar/siera-kube-watch/config"
+	"github.com/warungpintar/siera-kube-watch/util"
+)
+
+func Ping() {
+	if config.GlobalConfig.Livenesscheck.Enabled {
+
+		interval, err := time.ParseDuration(config.GlobalConfig.Livenesscheck.Interval)
+
+		if err != nil {
+			log.Fatalf("Error parsing livness check interval value: %v", err)
+		}
+
+		log.Printf("Liveness check enabled with interval: %s", interval)
+
+		intervalInSeconds := interval.Seconds()
+		for {
+			time.Sleep(time.Duration(intervalInSeconds) * time.Second)
+			util.PostEvent("This is a dead man's switch mechanism to ensure alert pipeline is working.")
+		}
+	}
+}

--- a/liveness-check/checker.go
+++ b/liveness-check/checker.go
@@ -21,8 +21,8 @@ func Ping() {
 
 		intervalInSeconds := interval.Seconds()
 		for {
-			time.Sleep(time.Duration(intervalInSeconds) * time.Second)
 			util.PostEvent("This is a dead man's switch mechanism to ensure alert pipeline is working.")
+			time.Sleep(time.Duration(intervalInSeconds) * time.Second)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/warungpintar/siera-kube-watch/config"
 	"log"
+
+	"github.com/warungpintar/siera-kube-watch/config"
+	liveness_check "github.com/warungpintar/siera-kube-watch/liveness-check"
 
 	eventHandler "github.com/warungpintar/siera-kube-watch/event-handler"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -48,6 +50,8 @@ func main() {
 		DeleteFunc: eventHandler.OnDeleteEvent,
 		UpdateFunc: eventHandler.OnUpdateEvent,
 	})
+
+	go liveness_check.Ping()
 
 	go eventInformer.Run(eventStopper)
 

--- a/util/notify.go
+++ b/util/notify.go
@@ -2,10 +2,11 @@ package util
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/warungpintar/siera-kube-watch/config"
 	"github.com/warungpintar/siera-kube-watch/model"
 	corev1 "k8s.io/api/core/v1"
-	"log"
 )
 
 func NotifyEvent(event *corev1.Event) {
@@ -13,11 +14,11 @@ func NotifyEvent(event *corev1.Event) {
 		if !isExist(config.GlobalConfig.ExcludedReasons, event.Reason) {
 			if event.Type != NORMAL {
 				message := parseEventToMessage(event)
-				postEvent(message)
+				PostEvent(message)
 			} else {
 				if isExist(config.GlobalConfig.IncludedReasons, event.Reason) {
 					message := parseEventToMessage(event)
-					postEvent(message)
+					PostEvent(message)
 				}
 			}
 		}
@@ -47,7 +48,7 @@ func isExist(arr []string, element string) bool {
 	return false
 }
 
-func postEvent(message string) {
+func PostEvent(message string) {
 	if config.GlobalConfig.Webhook.Enabled {
 		model := model.StdModel{}
 		model.New(message)


### PR DESCRIPTION
Hi team,

This PR adds dead man's switch functionality to help in monitoring the availability of the alert pipeline (communication between siera-kube-watch & notify targets).
It functions similar to what is mentioned here https://docs.openshift.com/container-platform/3.11/install_config/prometheus_cluster_monitoring.html#dead-mans-switch_prometheus-cluster-monitoring.